### PR TITLE
isomorphic main

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,41 +1,48 @@
 #![deny(unsafe_code)]
 
-#[cfg(any(
-    not(any(feature = "web", feature = "server")),
-    all(feature = "web", feature = "server")
-))]
-fn main() {
-    compile_error!("exactly one of either feature must be enabled: web, server");
-}
+pub fn main() -> anyhow::Result<()> {
+    #[cfg(any(
+        not(any(feature = "web", feature = "server")),
+        all(feature = "web", feature = "server")
+    ))]
+    {
+        compile_error!("exactly one of either feature must be enabled: web, server");
+    }
 
-#[cfg(feature = "web")]
-fn main() -> anyhow::Result<()> {
-    use dioxus::LaunchBuilder;
+    #[cfg(feature = "web")]
+    {
+        use dioxus::LaunchBuilder;
 
-    tsto_server::logger::init()?;
-    LaunchBuilder::web().launch(tsto_server::app::dashboard::App);
+        tsto_server::logger::init()?;
+        LaunchBuilder::web().launch(tsto_server::app::dashboard::App);
 
-    Ok(())
-}
+        Ok(())
+    }
 
-#[cfg(feature = "server")]
-#[tokio::main]
-pub async fn main() -> anyhow::Result<()> {
-    use tracing::info;
-    use tsto_server::util::UPTIME;
+    #[cfg(feature = "server")]
+    {
+        use tracing::info;
+        use tsto_server::util::UPTIME;
 
-    tsto_server::logger::init()?;
-    tsto_server::database::init().await?;
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                tsto_server::logger::init()?;
+                tsto_server::database::init().await?;
 
-    info!("initializing server");
-    let router = tsto_server::app::create_router().await?;
-    let listener = tsto_server::app::create_listener().await?;
+                info!("initializing server");
+                let router = tsto_server::app::create_router().await?;
+                let listener = tsto_server::app::create_listener().await?;
 
-    // access UPTIME to initialize it as it is behind a lazy_static
-    UPTIME.elapsed().ok();
+                // access UPTIME to initialize it as it is behind a lazy_static
+                UPTIME.elapsed().ok();
 
-    info!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, router).await?;
+                info!("listening on {}", listener.local_addr().unwrap());
+                axum::serve(listener, router).await?;
 
-    Ok(())
+                Ok(())
+            })
+    }
 }


### PR DESCRIPTION
make main function isomorphic (deduplicated main).
when running clippy with `--all-features` it complains about multiple `main` functions. this is because server and web entry points both use a main fn.
